### PR TITLE
upgrade rubocop

### DIFF
--- a/battle_boats.gemspec
+++ b/battle_boats.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.42"
+  spec.add_development_dependency "rubocop", "~> 0.55"
   spec.add_development_dependency "simplecov", "~> 0.16"
 end


### PR DESCRIPTION
RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing local
users to exploit this to tamper with cache files belonging to other
users. ref: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418