### PR TITLE
Input Validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.4
+### New Features
+- Error messages for bad input
+- Prompt will ask again for input if input is invalid
+- Game loops for more than one strike
+
 # 0.0.3
 ### New Features
 - Can fire at an empty board and "miss" a target

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -19,6 +19,8 @@ module BattleBoats
       if validate_position(row: row)
         @play_area[row.to_i][column.to_i] = "X"
         @status_report = "Miss!"
+      else
+        false
       end
     end
 

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -16,7 +16,8 @@ module BattleBoats
     end
 
     def strike_position(row:, column:)
-      if validate_position(row: row)
+      validate_position(row: row)
+      if @error_messages.empty?
         @play_area[row.to_i][column.to_i] = "X"
         @status_report = "Miss!"
         true
@@ -29,11 +30,16 @@ module BattleBoats
 
     def validate_position(row:)
       @error_messages.clear
-      if row.to_s =~ /^[0-9]$/ && @play_area[row.to_i]
-        return true
-      else
+      if !between_zero_and_nine?(row)
         @error_messages << "The selected row is invalid"
-        return false
+      end
+    end
+
+    def between_zero_and_nine?(input)
+      if input.to_s =~ /^[0-9]$/
+        true
+      else
+        false
       end
     end
   end

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -26,6 +26,10 @@ module BattleBoats
       end
     end
 
+    def game_over?
+      false
+    end
+
     private
 
     def validate_position(row:, column:)

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -42,7 +42,7 @@ module BattleBoats
       end
       if @error_messages.empty?
         if !position_available?(row: row, column: column)
-         @error_messages << "That position has already been hit"
+          @error_messages << "That position has already been hit"
         end
       end
     end
@@ -56,7 +56,7 @@ module BattleBoats
     end
 
     def position_available?(row:, column:)
-      @play_area[row.to_i][column.to_i] != 'X'
+      @play_area[row.to_i][column.to_i] != "X"
     end
   end
 end

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -1,9 +1,10 @@
 module BattleBoats
   class Board
-    attr_reader :play_area, :status_report
+    attr_reader :play_area, :status_report, :error_messages
 
     def initialize
       @status_report = ""
+      @error_messages = []
       @play_area = []
       10.times do
         row = []
@@ -15,8 +16,22 @@ module BattleBoats
     end
 
     def strike_position(row:, column:)
-      @play_area[row.to_i][column.to_i] = "X"
-      @status_report = "Miss!"
+      if validate_position(row: row)
+        @play_area[row.to_i][column.to_i] = "X"
+        @status_report = "Miss!"
+      end
+    end
+
+    private
+
+    def validate_position(row:)
+      @error_messages.clear
+      if @play_area[row.to_i]
+        return true
+      else
+        @error_messages << "The selected row is invalid"
+        return false
+      end
     end
   end
 end

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -16,7 +16,7 @@ module BattleBoats
     end
 
     def strike_position(row:, column:)
-      validate_position(row: row)
+      validate_position(row: row, column: column)
       if @error_messages.empty?
         @play_area[row.to_i][column.to_i] = "X"
         @status_report = "Miss!"
@@ -28,10 +28,13 @@ module BattleBoats
 
     private
 
-    def validate_position(row:)
+    def validate_position(row:, column:)
       @error_messages.clear
       if !between_zero_and_nine?(row)
         @error_messages << "The selected row is invalid"
+      end
+      if !between_zero_and_nine?(column)
+        @error_messages << "The selected column is invalid"
       end
     end
 

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -40,6 +40,11 @@ module BattleBoats
       if !between_zero_and_nine?(column)
         @error_messages << "The selected column is invalid"
       end
+      if @error_messages.empty?
+        if !position_available?(row: row, column: column)
+         @error_messages << "That position has already been hit"
+        end
+      end
     end
 
     def between_zero_and_nine?(input)
@@ -48,6 +53,10 @@ module BattleBoats
       else
         false
       end
+    end
+
+    def position_available?(row:, column:)
+      @play_area[row.to_i][column.to_i] != 'X'
     end
   end
 end

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -19,6 +19,7 @@ module BattleBoats
       if validate_position(row: row)
         @play_area[row.to_i][column.to_i] = "X"
         @status_report = "Miss!"
+        true
       else
         false
       end

--- a/lib/battle_boats/board.rb
+++ b/lib/battle_boats/board.rb
@@ -26,7 +26,7 @@ module BattleBoats
 
     def validate_position(row:)
       @error_messages.clear
-      if @play_area[row.to_i]
+      if row.to_s =~ /^[0-9]$/ && @play_area[row.to_i]
         return true
       else
         @error_messages << "The selected row is invalid"

--- a/lib/battle_boats/console_ui.rb
+++ b/lib/battle_boats/console_ui.rb
@@ -27,6 +27,10 @@ module BattleBoats
       output.puts status_report
     end
 
+    def display_errors(errors)
+      output.puts errors
+    end
+
     private
 
     attr_reader :output, :input

--- a/lib/battle_boats/engine.rb
+++ b/lib/battle_boats/engine.rb
@@ -14,7 +14,10 @@ module BattleBoats
       interface.display_board(board)
       row = interface.get_row
       column = interface.get_column
-      board.strike_position(row: row, column: column)
+      until board.strike_position(row: row, column: column)
+        row = interface.get_row
+        column = interface.get_column
+      end
       status_report = board.status_report
       interface.display_status_report(status_report)
       interface.display_board(board)

--- a/lib/battle_boats/engine.rb
+++ b/lib/battle_boats/engine.rb
@@ -20,8 +20,7 @@ module BattleBoats
           row = interface.get_row
           column = interface.get_column
         end
-        status_report = board.status_report
-        interface.display_status_report(status_report)
+        interface.display_status_report(board.status_report)
       end
     end
 

--- a/lib/battle_boats/engine.rb
+++ b/lib/battle_boats/engine.rb
@@ -11,17 +11,18 @@ module BattleBoats
 
     def start
       interface.greet
-      interface.display_board(board)
-      row = interface.get_row
-      column = interface.get_column
-      until board.strike_position(row: row, column: column)
-        interface.display_errors(board.error_messages)
+      until board.game_over?
+        interface.display_board(board)
         row = interface.get_row
         column = interface.get_column
+        until board.strike_position(row: row, column: column)
+          interface.display_errors(board.error_messages)
+          row = interface.get_row
+          column = interface.get_column
+        end
+        status_report = board.status_report
+        interface.display_status_report(status_report)
       end
-      status_report = board.status_report
-      interface.display_status_report(status_report)
-      interface.display_board(board)
     end
 
     private

--- a/lib/battle_boats/engine.rb
+++ b/lib/battle_boats/engine.rb
@@ -15,6 +15,7 @@ module BattleBoats
       row = interface.get_row
       column = interface.get_column
       until board.strike_position(row: row, column: column)
+        interface.display_errors(board.error_messages)
         row = interface.get_row
         column = interface.get_column
       end

--- a/lib/battle_boats/version.rb
+++ b/lib/battle_boats/version.rb
@@ -1,3 +1,3 @@
 module BattleBoats
-  VERSION = "0.0.3".freeze
+  VERSION = "0.0.4".freeze
 end

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -65,4 +65,10 @@ RSpec.describe BattleBoats::Board do
       end
     end
   end
+
+  describe '#game_over?' do
+    it 'returns false' do
+      expect(board.game_over?).to eq false
+    end
+  end
 end

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -46,5 +46,23 @@ RSpec.describe BattleBoats::Board do
         expect(board.error_messages).to include('The selected row is invalid')
       end
     end
+    context 'when the column is not a valid row in the play area' do
+      it 'updates the error messages to include an "invalid column" statement' do
+        row = 0
+        column = 10
+        result = board.strike_position(row: row, column: column)
+        expect(result).to eq false
+        expect(board.error_messages).to include('The selected column is invalid')
+      end
+    end
+    context 'when the column is not a number between 0 and 9' do
+      it 'updates the error messages to include an "invalid column" statement' do
+        row = 0
+        column = "hello"
+        result = board.strike_position(row: row, column: column)
+        expect(result).to eq false
+        expect(board.error_messages).to include('The selected column is invalid')
+      end
+    end
   end
 end

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe BattleBoats::Board do
         expect(board.error_messages).to include('The selected column is invalid')
       end
     end
+    context 'when both the row and column are not valid' do
+      it 'updates the error messages to include an "invalid row" and "invalid column" statement' do
+        row = 420
+        column = "hello"
+        result = board.strike_position(row: row, column: column)
+        expect(result).to eq false
+        expect(board.error_messages).to include('The selected column is invalid')
+        expect(board.error_messages).to include('The selected row is invalid')
+      end
+    end
   end
 
   describe '#game_over?' do

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe BattleBoats::Board do
         it 'it strikes the cell and updates the status report' do
           row = 1
           column = 1
-          board.strike_position(row: row, column: column)
+          result = board.strike_position(row: row, column: column)
+          expect(result).to eq true
           expect(board.play_area[row][column]).to eq 'X'
           expect(board.status_report.downcase).to include 'miss'
         end

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe BattleBoats::Board do
       it 'updates the error messages to include an "invalid row" statement' do
         row = 10
         column = 0
-        board.strike_position(row: row, column: column)
+        result = board.strike_position(row: row, column: column)
+        expect(result).to eq false
         expect(board.error_messages).to include('The selected row is invalid')
       end
     end
@@ -39,7 +40,8 @@ RSpec.describe BattleBoats::Board do
       it 'updates the error messages to include an "invalid row" statement' do
         row = "hello"
         column = 0
-        board.strike_position(row: row, column: column)
+        result = board.strike_position(row: row, column: column)
+        expect(result).to eq false
         expect(board.error_messages).to include('The selected row is invalid')
       end
     end

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -27,5 +27,13 @@ RSpec.describe BattleBoats::Board do
         end
       end
     end
+    context 'when the row is not a valid row in the play area' do
+      it 'updates the error messages to include an "invalid row" statement' do
+        row = 10
+        column = 0
+        board.strike_position(row: row, column: column)
+        expect(board.error_messages).to include('The selected row is invalid')
+      end
+    end
   end
 end

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe BattleBoats::Board do
           expect(board.status_report.downcase).to include 'miss'
         end
       end
+      context 'when the cell has already been hit' do
+        it 'updates the error messages to include an "already hit" statement' do
+          row = 1
+          column = 1
+
+          board.strike_position(row: row, column: column)
+          result = board.strike_position(row: row, column: column)
+
+          expect(result).to eq false
+          expect(board.error_messages).to include('That position has already been hit')
+        end
+      end
     end
     context 'when the row is not a valid row in the play area' do
       it 'updates the error messages to include an "invalid row" statement' do

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -21,12 +21,15 @@ RSpec.describe BattleBoats::Board do
         it 'it strikes the cell and updates the status report' do
           row = 1
           column = 1
+
           result = board.strike_position(row: row, column: column)
+
           expect(result).to eq true
           expect(board.play_area[row][column]).to eq 'X'
           expect(board.status_report.downcase).to include 'miss'
         end
       end
+
       context 'when the cell has already been hit' do
         it 'updates the error messages to include an "already hit" statement' do
           row = 1
@@ -40,47 +43,62 @@ RSpec.describe BattleBoats::Board do
         end
       end
     end
+
     context 'when the row is not a valid row in the play area' do
       it 'updates the error messages to include an "invalid row" statement' do
         row = 10
         column = 0
+
         result = board.strike_position(row: row, column: column)
+
         expect(result).to eq false
         expect(board.error_messages).to include('The selected row is invalid')
       end
     end
+
     context 'when the row is not a number between 0 and 9' do
       it 'updates the error messages to include an "invalid row" statement' do
         row = "hello"
         column = 0
+
         result = board.strike_position(row: row, column: column)
+
         expect(result).to eq false
         expect(board.error_messages).to include('The selected row is invalid')
       end
     end
+
     context 'when the column is not a valid row in the play area' do
       it 'updates the error messages to include an "invalid column" statement' do
         row = 0
         column = 10
+
         result = board.strike_position(row: row, column: column)
+
         expect(result).to eq false
         expect(board.error_messages).to include('The selected column is invalid')
       end
     end
+
     context 'when the column is not a number between 0 and 9' do
       it 'updates the error messages to include an "invalid column" statement' do
         row = 0
         column = "hello"
+
         result = board.strike_position(row: row, column: column)
+
         expect(result).to eq false
         expect(board.error_messages).to include('The selected column is invalid')
       end
     end
+
     context 'when both the row and column are not valid' do
       it 'updates the error messages to include an "invalid row" and "invalid column" statement' do
         row = 420
         column = "hello"
+
         result = board.strike_position(row: row, column: column)
+
         expect(result).to eq false
         expect(board.error_messages).to include('The selected column is invalid')
         expect(board.error_messages).to include('The selected row is invalid')

--- a/spec/battle_boats/board_spec.rb
+++ b/spec/battle_boats/board_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe BattleBoats::Board do
         expect(board.error_messages).to include('The selected row is invalid')
       end
     end
+    context 'when the row is not a number between 0 and 9' do
+      it 'updates the error messages to include an "invalid row" statement' do
+        row = "hello"
+        column = 0
+        board.strike_position(row: row, column: column)
+        expect(board.error_messages).to include('The selected row is invalid')
+      end
+    end
   end
 end

--- a/spec/battle_boats/console_ui_spec.rb
+++ b/spec/battle_boats/console_ui_spec.rb
@@ -60,5 +60,15 @@ RSpec.describe BattleBoats::ConsoleUI do
       expect(output.string).to include(status_report)
     end
   end
+
+  describe '#display_errors' do
+    it 'displays the given errors to the output' do
+      errors = ['error_01', 'error_02']
+
+      console_ui.display_errors(errors)
+
+      expect(output.string).to include('error_01', 'error_02')
+    end
+  end
 end
 

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BattleBoats::Engine do
 
   describe '#start' do
     context 'when the row and column input is valid' do
-      it 'starts the game' do
+      it 'plays the game until it is over' do
         row = "row"
         column = "column"
         status_report = "STATUS REPORT"

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -10,21 +10,49 @@ RSpec.describe BattleBoats::Engine do
                                          board: board) }
 
   describe '#start' do
-    it 'starts the game' do
-      row = "row"
-      column = "column"
-      status_report = "STATUS REPORT"
+    context 'when the row and column input is valid' do
+      it 'starts the game' do
+        row = "row"
+        column = "column"
+        status_report = "STATUS REPORT"
 
-      expect(console_ui).to receive(:greet).ordered
-      expect(console_ui).to receive(:display_board).with(board).ordered
-      expect(console_ui).to receive(:get_row).and_return(row).ordered
-      expect(console_ui).to receive(:get_column).and_return(column).ordered
-      expect(board).to receive(:strike_position).with(row: row, column: column).ordered
-      expect(board).to receive(:status_report).and_return(status_report).ordered
-      expect(console_ui).to receive(:display_status_report).with(status_report).ordered
-      expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(console_ui).to receive(:greet).ordered
+        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(console_ui).to receive(:get_row).and_return(row).ordered
+        expect(console_ui).to receive(:get_column).and_return(column).ordered
+        expect(board).to receive(:strike_position).with(row: row, column: column).and_return(true).ordered
+        expect(board).to receive(:status_report).and_return(status_report).ordered
+        expect(console_ui).to receive(:display_status_report).with(status_report).ordered
+        expect(console_ui).to receive(:display_board).with(board).ordered
 
-      engine.start
+        engine.start
+      end
+    end
+    context 'when the row and column input is invalid' do
+      it 'prompts the user to re-enter a row and column' do
+        row = "row"
+        column = "column"
+        invalid_row = "invalid_row"
+        error_message = "error"
+        status_report = "STATUS REPORT"
+
+        expect(console_ui).to receive(:greet).ordered
+        expect(console_ui).to receive(:display_board).with(board).ordered
+
+        expect(console_ui).to receive(:get_row).and_return(invalid_row).ordered
+        expect(console_ui).to receive(:get_column).and_return(column).ordered
+        expect(board).to receive(:strike_position).with(row: invalid_row, column: column).and_return(false).ordered
+
+        expect(console_ui).to receive(:get_row).and_return(row).ordered
+        expect(console_ui).to receive(:get_column).and_return(column).ordered
+        expect(board).to receive(:strike_position).with(row: row, column: column).and_return(true).ordered
+
+        expect(board).to receive(:status_report).and_return(status_report).ordered
+        expect(console_ui).to receive(:display_status_report).with(status_report).ordered
+        expect(console_ui).to receive(:display_board).with(board).ordered
+
+        engine.start
+      end
     end
   end
 end

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -38,15 +38,17 @@ RSpec.describe BattleBoats::Engine do
 
         expect(console_ui).to receive(:greet).ordered
         expect(console_ui).to receive(:display_board).with(board).ordered
-
         expect(console_ui).to receive(:get_row).and_return(invalid_row).ordered
         expect(console_ui).to receive(:get_column).and_return(column).ordered
+
         expect(board).to receive(:strike_position).with(row: invalid_row, column: column).and_return(false).ordered
+        expect(board).to receive(:error_messages).and_return(error_message).ordered
+        expect(console_ui).to receive(:display_errors).with(error_message).ordered
 
         expect(console_ui).to receive(:get_row).and_return(row).ordered
         expect(console_ui).to receive(:get_column).and_return(column).ordered
-        expect(board).to receive(:strike_position).with(row: row, column: column).and_return(true).ordered
 
+        expect(board).to receive(:strike_position).with(row: row, column: column).and_return(true).ordered
         expect(board).to receive(:status_report).and_return(status_report).ordered
         expect(console_ui).to receive(:display_status_report).with(status_report).ordered
         expect(console_ui).to receive(:display_board).with(board).ordered

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe BattleBoats::Engine do
         status_report = "STATUS REPORT"
 
         expect(console_ui).to receive(:greet).ordered
+        expect(board).to receive(:game_over?).and_return(false)
         expect(console_ui).to receive(:display_board).with(board).ordered
         expect(console_ui).to receive(:get_row).and_return(row).ordered
         expect(console_ui).to receive(:get_column).and_return(column).ordered
         expect(board).to receive(:strike_position).with(row: row, column: column).and_return(true).ordered
         expect(board).to receive(:status_report).and_return(status_report).ordered
         expect(console_ui).to receive(:display_status_report).with(status_report).ordered
-        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(board).to receive(:game_over?).and_return(true)
 
         engine.start
       end
@@ -37,6 +38,7 @@ RSpec.describe BattleBoats::Engine do
         status_report = "STATUS REPORT"
 
         expect(console_ui).to receive(:greet).ordered
+        expect(board).to receive(:game_over?).and_return(false)
         expect(console_ui).to receive(:display_board).with(board).ordered
         expect(console_ui).to receive(:get_row).and_return(invalid_row).ordered
         expect(console_ui).to receive(:get_column).and_return(column).ordered
@@ -51,7 +53,7 @@ RSpec.describe BattleBoats::Engine do
         expect(board).to receive(:strike_position).with(row: row, column: column).and_return(true).ordered
         expect(board).to receive(:status_report).and_return(status_report).ordered
         expect(console_ui).to receive(:display_status_report).with(status_report).ordered
-        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(board).to receive(:game_over?).and_return(true)
 
         engine.start
       end

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe BattleBoats::Engine do
         engine.start
       end
     end
+
     context 'when the row and column input is invalid' do
       it 'prompts the user to re-enter a row and column' do
         row = "row"


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/157518138

This PR introduces input validations and error messages. All row and column inputs must be a single digit between `0` and `9`, and the selected position must not have previously been selected.

The onus of validating input in on the `board#strike_position` method, which will return `false` and update the `error_messages` attribute on the `board` object with detailed messages regarding the reason why the strike has failed, similar to Rails model object's `#update` method. 