### PR TITLE
Re-tool dev mode console interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.10
+### New Features
+- `battle_boats "dev"` will play in developer mode
+- Randomly placed ships will be visible 
+
 # 0.0.9
 ### New Features
 - Displays "won" message once all the ship are sunk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    battle_boats (0.0.9)
+    battle_boats (0.0.10)
 
 GEM
   remote: https://rubygems.org/

--- a/bin/battle_boats
+++ b/bin/battle_boats
@@ -2,11 +2,17 @@
 
 require 'battle_boats/engine'
 require 'battle_boats/board'
-require 'battle_boats/fleet'
-require 'battle_boats/coordinate'
+require 'battle_boats/dev_console_ui'
 
 board = BattleBoats::Board.new
 board.place_ships_randomly
-engine = BattleBoats::Engine.new(board: board)
+
+if ARGV[0] == "dev"
+  interface = BattleBoats::DevConsoleUI.new
+else
+  interface = BattleBoats::ConsoleUI.new
+end
+
+engine = BattleBoats::Engine.new(board: board, interface: interface)
 engine.start
 

--- a/lib/battle_boats/cell.rb
+++ b/lib/battle_boats/cell.rb
@@ -24,9 +24,9 @@ module BattleBoats
 
     def to_s
       if hit?
-        occupant.symbol
+        occupant.to_ansi
       else
-        "~".blue
+        to_ansi
       end
     end
 
@@ -41,6 +41,12 @@ module BattleBoats
 
     def occupied?
       !occupant.empty?
+    end
+
+    private
+
+    def to_ansi
+      "~".blue
     end
   end
 end

--- a/lib/battle_boats/dev_console_ui.rb
+++ b/lib/battle_boats/dev_console_ui.rb
@@ -1,0 +1,35 @@
+require_relative "console_ui"
+require_relative "coordinate"
+require_relative "colorize"
+
+module BattleBoats
+  class DevConsoleUI < ConsoleUI
+    using Colorize
+    def format_board(board)
+      board_string = horizontal_line
+      board_string << newline
+      board_string << column_label
+      board_string << horizontal_line
+      board_string << newline
+      board.play_area.each_with_index do |row, row_number|
+        board_string << pipe
+        board_string << "  #{row_labels[row_number]}  "
+        board_string << pipe
+        row.each do |cell|
+          board_string << if cell.hit?
+                            "  #{cell.occupant.symbol.red}  "
+                          elsif cell.occupied?
+                            "  #{cell.occupant.symbol.yellow}  "
+                          else
+                            "  #{cell.occupant.symbol.blue}  "
+                          end
+          board_string << pipe
+        end
+        board_string << newline
+        board_string << horizontal_line
+        board_string << newline
+      end
+      board_string
+    end
+  end
+end

--- a/lib/battle_boats/null_ship.rb
+++ b/lib/battle_boats/null_ship.rb
@@ -8,11 +8,15 @@ module BattleBoats
     def initialize
       @name = "nothing"
       @length = 1
-      @symbol = "X".yellow
+      @symbol = "X"
     end
 
     def empty?
       true
+    end
+
+    def to_ansi
+      @symbol.yellow
     end
 
     def hit; end

--- a/lib/battle_boats/ship.rb
+++ b/lib/battle_boats/ship.rb
@@ -20,16 +20,12 @@ module BattleBoats
       @symbol.red
     end
 
-    def hit_count
-      @hits
-    end
-
     def hit
       @hits += 1
     end
 
     def sunk?
-      hit_count == length
+      @hits == length
     end
   end
 end

--- a/lib/battle_boats/ship.rb
+++ b/lib/battle_boats/ship.rb
@@ -8,12 +8,16 @@ module BattleBoats
     def initialize(name:, length:, symbol: "O")
       @name = name
       @length = length
-      @symbol = symbol.red
+      @symbol = symbol
       @hits = 0
     end
 
     def empty?
       false
+    end
+
+    def to_ansi
+      @symbol.red
     end
 
     def hit_count

--- a/lib/battle_boats/version.rb
+++ b/lib/battle_boats/version.rb
@@ -1,3 +1,3 @@
 module BattleBoats
-  VERSION = "0.0.9".freeze
+  VERSION = "0.0.10".freeze
 end

--- a/spec/battle_boats/null_ship_spec.rb
+++ b/spec/battle_boats/null_ship_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe BattleBoats::NullShip do
       expect(ship.symbol).to include "X"
     end
   end
+  describe "#to_ansi" do
+    it "returns a ANSI colorized symbol of a ship" do
+      ship = BattleBoats::NullShip.new
+
+      expect(ship.to_ansi).to include ship.symbol
+    end
+  end
   describe "#empty?" do
     it "returns true" do
       ship = BattleBoats::NullShip.new

--- a/spec/battle_boats/ship_spec.rb
+++ b/spec/battle_boats/ship_spec.rb
@@ -32,24 +32,15 @@ RSpec.describe BattleBoats::Ship do
       expect(ship).to_not be_empty
     end
   end
-  describe "#hit_count" do
-    context "when the ship has not been hit" do
-      it "returns zero" do
-        ship = BattleBoats::Ship.new(name: nil, length: 2)
-
-        expect(ship.hit_count).to eq 0
-      end
-    end
-  end
   describe "#hit" do
     it "increases the hit_count by one" do
       ship = BattleBoats::Ship.new(name: nil, length: 2)
 
-      expect(ship.hit_count).to eq 0
+      expect(ship.instance_variable_get(:@hits)).to eq 0
 
       ship.hit
 
-      expect(ship.hit_count).to be 1
+      expect(ship.instance_variable_get(:@hits)).to eq 1
     end
   end
   describe "#sunk?" do

--- a/spec/battle_boats/ship_spec.rb
+++ b/spec/battle_boats/ship_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe BattleBoats::Ship do
       expect(ship.symbol).to include symbol
     end
   end
+  describe "#to_ansi" do
+    it "returns a ANSI colorized symbol of a ship" do
+      ship = BattleBoats::Ship.new(name: nil, length: nil)
+
+      expect(ship.to_ansi).to include ship.symbol
+    end
+  end
   describe "#empty?" do
     it "returns false" do
       ship = BattleBoats::Ship.new(name: nil, length: nil)


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/157736285

## Description
Running the game with the `battle_boats "dev"` will run the game in "developer" mode. All of the randomly placed ships will be visible during game play. This required moving some of the `Colorize` logic out of the the `ship#symbol`s, so that `symbol` could be colorized independently.