### PR TITLE
Player Can Place Ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.0
+### New Features 
+- At the start of the game, the user will be prompted to place their ships on their board
+- After all ships are place, the game will continue as it previously had
+
 # 0.0.20
 ### Breaking Change
 - `battle_boats "dev"` is not longer available

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    battle_boats (0.0.20)
+    battle_boats (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/bin/battle_boats
+++ b/bin/battle_boats
@@ -3,9 +3,10 @@
 require 'battle_boats/engine'
 require 'battle_boats/board'
 
-board = BattleBoats::Board.new
-board.place_ships_randomly
+enemy_board = BattleBoats::Board.new
+enemy_board.place_ships_randomly
 
-engine = BattleBoats::Engine.new(board: board)
+engine = BattleBoats::Engine.new(enemy_board: enemy_board)
+engine.place_ships_manually
 engine.start
 

--- a/lib/battle_boats/engine.rb
+++ b/lib/battle_boats/engine.rb
@@ -4,28 +4,30 @@ require_relative "console_ui"
 module BattleBoats
   class Engine
     def initialize(interface: BattleBoats::ConsoleUI.new,
-                   board: BattleBoats::Board.new)
+                   enemy_board: BattleBoats::Board.new,
+                   ally_board: BattleBoats::Board.new)
       @interface = interface
-      @board = board
+      @enemy_board = enemy_board
+      @ally_board = ally_board
     end
 
     def start
       interface.greet
-      until board.game_over?
-        interface.display_board(board)
+      until enemy_board.game_over?
+        interface.display_board(enemy_board)
         coordinate = interface.get_coordinate
-        until board.strike_position(coordinate: coordinate)
-          interface.display_status_report(board.status_report)
+        until enemy_board.strike_position(coordinate: coordinate)
+          interface.display_status_report(enemy_board.status_report)
           coordinate = interface.get_coordinate
         end
-        interface.display_status_report(board.status_report)
+        interface.display_status_report(enemy_board.status_report)
       end
       interface.win
-      interface.display_board(board)
+      interface.display_board(enemy_board)
     end
 
     private
 
-    attr_reader :interface, :board
+    attr_reader :interface, :enemy_board, :ally_board
   end
 end

--- a/lib/battle_boats/engine.rb
+++ b/lib/battle_boats/engine.rb
@@ -11,6 +11,20 @@ module BattleBoats
       @ally_board = ally_board
     end
 
+    def place_ships_manually
+      ally_board.fleet.ships.each do |ship|
+        until ally_board.ship_deployed?(ship: ship)
+          interface.display_ally_board(ally_board)
+          interface.display_ship_data(ship: ship)
+          coordinate = interface.get_coordinate
+          orientation = interface.get_orientation
+          ally_board.attempt_to_deploy_ship(ship: ship,
+                                            coordinate: coordinate,
+                                            orientation: orientation)
+        end
+      end
+    end
+
     def start
       interface.greet
       until enemy_board.game_over?

--- a/lib/battle_boats/version.rb
+++ b/lib/battle_boats/version.rb
@@ -1,3 +1,3 @@
 module BattleBoats
-  VERSION = "0.0.20".freeze
+  VERSION = "0.1.0".freeze
 end

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BattleBoats::Engine do
                         ally_board: ally_board)
   end
 
-  describe "deploy_ally_ships" do
+  describe "#place_ships_manually" do
     it "walks the user through deploying their ships until all ships are deployed" do
       ship = BattleBoats::Ship.new(name: "foo", length: 1, symbol: "F")
       ships = [ship]
@@ -33,7 +33,7 @@ RSpec.describe BattleBoats::Engine do
       expect(ally_board).to receive(:attempt_to_deploy_ship).with(ship: ship,
                                                                   coordinate: coordinate,
                                                                   orientation: orientation)
-      engine.deploy_ally_ships
+      engine.place_ships_manually
     end
   end
 

--- a/spec/battle_boats/engine_spec.rb
+++ b/spec/battle_boats/engine_spec.rb
@@ -1,14 +1,40 @@
 require "battle_boats/engine"
 require "battle_boats/console_ui"
 require "battle_boats/board"
+require "battle_boats/fleet"
 require "battle_boats/coordinate"
 
 RSpec.describe BattleBoats::Engine do
   let(:console_ui) { instance_double(BattleBoats::ConsoleUI) }
-  let(:board) { instance_double(BattleBoats::Board) }
+  let(:ally_board) { instance_double(BattleBoats::Board) }
+  let(:fleet) { instance_double(BattleBoats::Fleet) }
+  let(:enemy_board) { instance_double(BattleBoats::Board) }
   subject(:engine) do
     described_class.new(interface: console_ui,
-                        board: board)
+                        enemy_board: enemy_board,
+                        ally_board: ally_board)
+  end
+
+  describe "deploy_ally_ships" do
+    it "walks the user through deploying their ships until all ships are deployed" do
+      ship = BattleBoats::Ship.new(name: "foo", length: 1, symbol: "F")
+      ships = [ship]
+      coordinate = BattleBoats::Coordinate.new(row: 0, column: 0)
+      orientation = :horizontal
+
+      allow(ally_board).to receive(:fleet).and_return(fleet)
+      allow(fleet).to receive(:ships).and_return(ships)
+      allow(ally_board).to receive(:ship_deployed?).with(ship: ship).and_return(false, true)
+      allow(console_ui).to receive(:display_ally_board).with(ally_board)
+      allow(console_ui).to receive(:display_ship_data).with(ship: ship)
+      allow(console_ui).to receive(:get_coordinate).and_return(coordinate)
+      allow(console_ui).to receive(:get_orientation).and_return(orientation)
+
+      expect(ally_board).to receive(:attempt_to_deploy_ship).with(ship: ship,
+                                                                  coordinate: coordinate,
+                                                                  orientation: orientation)
+      engine.deploy_ally_ships
+    end
   end
 
   describe "#start" do
@@ -20,15 +46,15 @@ RSpec.describe BattleBoats::Engine do
         status_report = "STATUS REPORT"
 
         expect(console_ui).to receive(:greet).ordered
-        expect(board).to receive(:game_over?).and_return(false)
-        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(enemy_board).to receive(:game_over?).and_return(false)
+        expect(console_ui).to receive(:display_board).with(enemy_board).ordered
         expect(console_ui).to receive(:get_coordinate).and_return(coordinate).ordered
-        expect(board).to receive(:strike_position).with(coordinate: coordinate).and_return(true).ordered
-        expect(board).to receive(:status_report).and_return(status_report).ordered
+        expect(enemy_board).to receive(:strike_position).with(coordinate: coordinate).and_return(true).ordered
+        expect(enemy_board).to receive(:status_report).and_return(status_report).ordered
         expect(console_ui).to receive(:display_status_report).with(status_report).ordered
-        expect(board).to receive(:game_over?).and_return(true)
+        expect(enemy_board).to receive(:game_over?).and_return(true)
         expect(console_ui).to receive(:win)
-        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(console_ui).to receive(:display_board).with(enemy_board).ordered
 
         engine.start
       end
@@ -45,22 +71,22 @@ RSpec.describe BattleBoats::Engine do
         status_report = "STATUS REPORT"
 
         expect(console_ui).to receive(:greet).ordered
-        expect(board).to receive(:game_over?).and_return(false)
-        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(enemy_board).to receive(:game_over?).and_return(false)
+        expect(console_ui).to receive(:display_board).with(enemy_board).ordered
         expect(console_ui).to receive(:get_coordinate).and_return(invalid_coordinate).ordered
 
-        expect(board).to receive(:strike_position).with(coordinate: invalid_coordinate).and_return(false).ordered
-        expect(board).to receive(:status_report).and_return(error_message).ordered
+        expect(enemy_board).to receive(:strike_position).with(coordinate: invalid_coordinate).and_return(false).ordered
+        expect(enemy_board).to receive(:status_report).and_return(error_message).ordered
         expect(console_ui).to receive(:display_status_report).with(error_message).ordered
 
         expect(console_ui).to receive(:get_coordinate).and_return(coordinate).ordered
 
-        expect(board).to receive(:strike_position).with(coordinate: coordinate).and_return(true).ordered
-        expect(board).to receive(:status_report).and_return(status_report).ordered
+        expect(enemy_board).to receive(:strike_position).with(coordinate: coordinate).and_return(true).ordered
+        expect(enemy_board).to receive(:status_report).and_return(status_report).ordered
         expect(console_ui).to receive(:display_status_report).with(status_report).ordered
-        expect(board).to receive(:game_over?).and_return(true)
+        expect(enemy_board).to receive(:game_over?).and_return(true)
         expect(console_ui).to receive(:win)
-        expect(console_ui).to receive(:display_board).with(board).ordered
+        expect(console_ui).to receive(:display_board).with(enemy_board).ordered
 
         engine.start
       end


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/157321743

## Description 
`Engine` has the responsibility of walking the user through deploying ships. This made sense to me because `Engine` is already for the collaboration between `Board` and `Interface`, which are both needed to make this happen.

This introduces the domain concept of `enemy_board` and `ally_board`.

It feels strange that the responsibility of deploying ships is split between `Board`, which handles deploying ships randomly, and `Engine`, which allows a player to deploy ships manually.