### PR TITLE
Development Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.2
+### New Features
+- Replaced -d and --development option flags to enter developer mode
+- Enemy ships are visible in developer mode
+
 # 0.2.1
 ### Enhancements
 - Various enhancements and bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    battle_boats (0.2.1)
+    battle_boats (0.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/bin/battle_boats
+++ b/bin/battle_boats
@@ -3,6 +3,11 @@
 require 'battle_boats/engine'
 require 'battle_boats/board'
 
+if ARGV[0] == "-d" || ARGV[0] == "--development"
+  BattleBoats::DEVELOPMENT = true
+end
+  
+
 enemy_board = BattleBoats::Board.new
 enemy_board.place_ships_randomly
 

--- a/lib/battle_boats/console_ui.rb
+++ b/lib/battle_boats/console_ui.rb
@@ -1,5 +1,6 @@
 require_relative "coordinate"
 require_relative "board_formatter"
+require_relative "environment"
 
 module BattleBoats
   class ConsoleUI
@@ -16,7 +17,8 @@ module BattleBoats
     end
 
     def display_board(board)
-      output.puts board_formatter.format_board(board, hide_ships: true)
+      hide_ships = false if BattleBoats::DEVELOPMENT
+      output.puts board_formatter.format_board(board, hide_ships: hide_ships)
     end
 
     def display_ally_board(board)

--- a/lib/battle_boats/console_ui.rb
+++ b/lib/battle_boats/console_ui.rb
@@ -17,7 +17,11 @@ module BattleBoats
     end
 
     def display_board(board)
-      hide_ships = false if BattleBoats::DEVELOPMENT
+      if BattleBoats::DEVELOPMENT
+        hide_ships = false
+      else
+        hide_ships = true
+      end
       output.puts board_formatter.format_board(board, hide_ships: hide_ships)
     end
 

--- a/lib/battle_boats/console_ui.rb
+++ b/lib/battle_boats/console_ui.rb
@@ -17,11 +17,7 @@ module BattleBoats
     end
 
     def display_board(board)
-      hide_ships = if BattleBoats::DEVELOPMENT
-                     false
-                   else
-                     true
-                   end
+      hide_ships = !BattleBoats::DEVELOPMENT
       output.puts board_formatter.format_board(board, hide_ships: hide_ships)
     end
 

--- a/lib/battle_boats/console_ui.rb
+++ b/lib/battle_boats/console_ui.rb
@@ -17,11 +17,11 @@ module BattleBoats
     end
 
     def display_board(board)
-      if BattleBoats::DEVELOPMENT
-        hide_ships = false
-      else
-        hide_ships = true
-      end
+      hide_ships = if BattleBoats::DEVELOPMENT
+                     false
+                   else
+                     true
+                   end
       output.puts board_formatter.format_board(board, hide_ships: hide_ships)
     end
 

--- a/lib/battle_boats/environment.rb
+++ b/lib/battle_boats/environment.rb
@@ -1,0 +1,3 @@
+module BattleBoats
+  DEVELOPMENT = false
+end

--- a/lib/battle_boats/version.rb
+++ b/lib/battle_boats/version.rb
@@ -1,3 +1,3 @@
 module BattleBoats
-  VERSION = "0.2.1".freeze
+  VERSION = "0.2.2".freeze
 end


### PR DESCRIPTION
## Pivotal Link
https://www.pivotaltracker.com/story/show/158266032

## Description
This PR replaces "development mode", which allows you to play the game with the enemy ships visible.

To enter development mode, pass the `-d` or `--development` option into the `battle_boats` command when beginning the game